### PR TITLE
Fixed config file comments to contain the actual logstore plugin names

### DIFF
--- a/etc/modules/livestatus.cfg
+++ b/etc/modules/livestatus.cfg
@@ -12,9 +12,9 @@ define module {
     port            50000       ; port to listen
     #socket          /usr/local/shinken/var/rw/live  ; If a Unix socket is required
     ## Available modules:
-    # - logsqlite: send historical logs to a local sqlite database
-    # - mongologs: send historical logs to a mongodb database
-    # - nulllogs : send historical logs to a black hole
+    # - logstore-sqlite: send historical logs to a local sqlite database
+    # - logstore-mongodb: send historical logs to a mongodb database
+    # - logstore-null : send historical logs to a black hole
     modules         logsqlite
     #debug           /tmp/ls.debug   ; Enable only for debugging this module
     #debug_queries   0   ; Set to 1 to dump queries/replies too (very verbose)


### PR DESCRIPTION
Just a small thing to make configuration easier for newcomers
