### PR TITLE
Fix encoding excetion with non ascii char

### DIFF
--- a/module/livestatus_client_thread.py
+++ b/module/livestatus_client_thread.py
@@ -90,10 +90,10 @@ class LiveStatusClientThread(threading.Thread):
         buf = b''
         for idx, data in enumerate(self.buffer_list):
             buf += data
-            endline = buf.find('\n\n')
+            endline = buf.find(b'\n\n')
             sz = 2
             if endline < 0:
-                endline = buf.find('\r\n\r\n')
+                endline = buf.find(b'\r\n\r\n')
                 sz = 4
             if endline >= 0:
                 for di in range(idx):

--- a/module/log_line.py
+++ b/module/log_line.py
@@ -64,7 +64,9 @@ class Logline(dict):
                 else:
                     setattr(self, col[0], sqlite_row[idx])
         elif line != None:
-            line = line.encode('UTF-8').rstrip()
+            if isinstance(line, unicode):
+                line = line.encode('UTF-8').rstrip()
+
             # [1278280765] SERVICE ALERT: test_host_0
             if line[0] != '[' and line[11] != ']':
                 logger.warning("[Livestatus Log Lines] Invalid line: %s" % line)

--- a/test/test_livestatus.py
+++ b/test/test_livestatus.py
@@ -44,6 +44,7 @@ from shinken.pollerlink import PollerLink
 from shinken.brokerlink import BrokerLink
 
 from shinken_modules import TestConfig
+from shinken_modules import LiveStatusClientThread
 
 from mock_livestatus import mock_livestatus_handle_request
 
@@ -71,6 +72,13 @@ class LiveStatusTest(TestConfig):
 
 @mock_livestatus_handle_request
 class TestConfigSmall(LiveStatusTest):
+
+    def test_get_request_encoding(self):
+        self.print_header()
+        lqt = LiveStatusClientThread(None, None, self.livestatus_broker)
+        lqt.buffer_list = [b'testééé\n\n']
+        output = lqt.get_request()
+        self.assertEqual(b"testééé\n\n", output)
 
     def test_check_type(self):
         self.print_header()


### PR DESCRIPTION
This fix two things : 
An exception raised when strange character where in a command
An exception in livestatus modules when logging brok with bad char.
