### PR TITLE
Enh: implemented transparent update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.ropeproject

--- a/module/livestatus_regenerator.py
+++ b/module/livestatus_regenerator.py
@@ -26,10 +26,21 @@ import types
 #import time
 from shinken.objects import Contact
 from shinken.objects import NotificationWay
+from shinken.objects import Hosts
+from shinken.objects import Services
+import copy
 from shinken.misc.regenerator import Regenerator
 from shinken.util import safe_print, get_obj_full_name
 from shinken.log import logger
-from livestatus_query_metainfo import HINT_NONE, HINT_HOST, HINT_HOSTS, HINT_SERVICES_BY_HOST, HINT_SERVICE, HINT_SERVICES_BY_HOSTS, HINT_SERVICES, HINT_HOSTS_BY_GROUP, HINT_SERVICES_BY_GROUP, HINT_SERVICES_BY_HOSTGROUP
+from livestatus_query_metainfo import HINT_HOST, HINT_HOSTS, \
+    HINT_SERVICES_BY_HOST, HINT_SERVICE, HINT_SERVICES_BY_HOSTS, HINT_SERVICES, \
+    HINT_HOSTS_BY_GROUP, HINT_SERVICES_BY_GROUP, HINT_SERVICES_BY_HOSTGROUP
+
+
+
+def notready(self, hints=None):
+    logger.info("[Livestatus Regenerator] loading in progress, service not yet ready.")
+    return iter([])
 
 
 def itersorted(self, hints=None):
@@ -49,7 +60,10 @@ def itersorted(self, hints=None):
             pass
     elif hints['target'] == HINT_HOSTS:
         try:
-            preselected_ids = [self._id_by_host_name_heap[h] for h in hints['host_name'] if h in self._id_by_host_name_heap]
+            preselected_ids = [
+                self._id_by_host_name_heap[h] for h in hints['host_name']
+                if h in self._id_by_host_name_heap
+            ]
             preselection = True
         except Exception, exp:
             # This host is unknown
@@ -70,20 +84,31 @@ def itersorted(self, hints=None):
             pass
     elif hints['target'] == HINT_SERVICE:
         try:
-            preselected_ids = [self._id_by_service_name_heap[hints['host_name'] + '/' + hints['service_description']]]
+            preselected_ids = [
+                self._id_by_service_name_heap[
+                    hints['host_name'] + '/' + hints['service_description']
+                ]
+            ]
             preselection = True
         except Exception:
             pass
     elif hints['target'] == HINT_SERVICES:
         try:
-            preselected_ids = [self._id_by_service_name_heap[host_name + '/' + service_description] for host_name, service_description in hints['host_names_service_descriptions'] if host_name + '/' + service_description in self._id_by_service_name_heap]
+            preselected_ids = [
+                self._id_by_service_name_heap[host_name + '/' + service_description]
+                for host_name, service_description in hints['host_names_service_descriptions']
+                if host_name + '/' + service_description in self._id_by_service_name_heap
+            ]
             preselection = True
         except Exception, exp:
             logger.error("[Livestatus Regenerator] Hint_services exception: %s" % exp)
             pass
     elif hints['target'] == HINT_SERVICES_BY_HOSTS:
         try:
-            preselected_ids = [id for h in hints['host_name'] if h in self._id_by_host_name_heap for id in self._id_by_host_name_heap[h]]
+            preselected_ids = [
+                id for h in hints['host_name'] if h in self._id_by_host_name_heap
+                for id in self._id_by_host_name_heap[h]
+            ]
             preselection = True
         except Exception:
             pass
@@ -101,35 +126,69 @@ def itersorted(self, hints=None):
         except Exception, exp:
             # This service is unknown
             pass
+
     if 'authuser' in hints:
         if preselection:
-            try:
-                for id in [pid for pid in preselected_ids if pid in self._id_contact_heap[hints['authuser']]]:
-                    yield self.items[id]
-            except Exception:
-                # this hints['authuser'] was not in self._id_contact_heap
-                # we do nothing, so the caller gets an empty list
-                pass
+            source = [
+                pid for pid in preselected_ids
+                if pid in self._id_contact_heap[hints['authuser']]
+            ]
         else:
-            try:
-                for id in self._id_contact_heap[hints['authuser']]:
-                    yield self.items[id]
-            except Exception:
-                pass
+            source = self._id_contact_heap[hints['authuser']]
     else:
         if preselection:
-            for id in preselected_ids:
-                yield self.items[id]
+            source = preselected_ids
         else:
-            for id in self._id_heap:
-                yield self.items[id]
+            source = self._id_heap
+    try:
+        for id in source:
+            yield self.items[id]
+    except KeyError:
+        # the id was not found. It's typically the case when a new configuration
+        # has been loaded
+        pass
 
 
 class LiveStatusRegenerator(Regenerator):
-    def __init__(self, service_authorization_strict=False, group_authorization_strict=True):
+
+    rollover_attributes = {
+        'hosts': Hosts,
+        'services': Services,
+    }
+
+    def __init__(self, service_authorization_strict=False,
+                 group_authorization_strict=True, transparent_update=False):
         super(LiveStatusRegenerator, self).__init__()
         self.service_authorization_strict = service_authorization_strict
         self.group_authorization_strict = group_authorization_strict
+        self.transparent_update = transparent_update
+        if self.transparent_update:
+            self.clear_previous_state()
+        self.set_null_sort()
+        self.initialized = False
+
+    def set_null_sort(self):
+        """
+        Sets an initial __itersorted__ method that indicates data is
+        currently being loaded, rather than raising an exception because
+        the method does not exist.
+        """
+        setattr(self.services, '__itersorted__',
+                types.MethodType(notready, self.services))
+        setattr(self.hosts, '__itersorted__',
+                types.MethodType(notready, self.hosts))
+        setattr(self.contacts, '__itersorted__',
+                types.MethodType(notready, self.contacts))
+        setattr(self.servicegroups, '__itersorted__',
+                types.MethodType(notready, self.servicegroups))
+        setattr(self.hostgroups, '__itersorted__',
+                types.MethodType(notready, self.hostgroups))
+        setattr(self.contactgroups, '__itersorted__',
+                types.MethodType(notready, self.contactgroups))
+        setattr(self.commands, '__itersorted__',
+                types.MethodType(notready, self.commands))
+        setattr(self.timeperiods, '__itersorted__',
+                types.MethodType(notready, self.timeperiods))
 
     def all_done_linking(self, inst_id):
         """In addition to the original all_done_linking our items will get sorted"""
@@ -143,30 +202,54 @@ class LiveStatusRegenerator(Regenerator):
         # First install a new attribute _id_heap, which holds the
         # item ids in sorted order
         setattr(self.services, '_id_heap', self.services.items.keys())
-        self.services._id_heap.sort(key=lambda x: get_obj_full_name(self.services.items[x]))
+        self.services._id_heap.sort(
+            key=lambda x: get_obj_full_name(self.services.items[x])
+        )
         setattr(self.hosts, '_id_heap', self.hosts.items.keys())
-        self.hosts._id_heap.sort(key=lambda x: get_obj_full_name(self.hosts.items[x]))
+        self.hosts._id_heap.sort(
+            key=lambda x: get_obj_full_name(self.hosts.items[x])
+        )
         setattr(self.contacts, '_id_heap', self.contacts.items.keys())
-        self.contacts._id_heap.sort(key=lambda x: get_obj_full_name(self.contacts.items[x]))
+        self.contacts._id_heap.sort(
+            key=lambda x: get_obj_full_name(self.contacts.items[x])
+        )
         setattr(self.servicegroups, '_id_heap', self.servicegroups.items.keys())
-        self.servicegroups._id_heap.sort(key=lambda x: get_obj_full_name(self.servicegroups.items[x]))
+        self.servicegroups._id_heap.sort(
+            key=lambda x: get_obj_full_name(self.servicegroups.items[x])
+        )
         setattr(self.hostgroups, '_id_heap', self.hostgroups.items.keys())
-        self.hostgroups._id_heap.sort(key=lambda x: get_obj_full_name(self.hostgroups.items[x]))
+        self.hostgroups._id_heap.sort(
+            key=lambda x: get_obj_full_name(self.hostgroups.items[x])
+        )
         setattr(self.contactgroups, '_id_heap', self.contactgroups.items.keys())
-        self.contactgroups._id_heap.sort(key=lambda x: get_obj_full_name(self.contactgroups.items[x]))
+        self.contactgroups._id_heap.sort(
+            key=lambda x: get_obj_full_name(self.contactgroups.items[x])
+        )
         setattr(self.commands, '_id_heap', self.commands.items.keys())
-        self.commands._id_heap.sort(key=lambda x: get_obj_full_name(self.commands.items[x]))
+        self.commands._id_heap.sort(
+            key=lambda x: get_obj_full_name(self.commands.items[x])
+        )
         setattr(self.timeperiods, '_id_heap', self.timeperiods.items.keys())
-        self.timeperiods._id_heap.sort(key=lambda x: get_obj_full_name(self.timeperiods.items[x]))
+        self.timeperiods._id_heap.sort(
+            key=lambda x: get_obj_full_name(self.timeperiods.items[x])
+        )
         # Then install a method for accessing the lists' elements in sorted order
-        setattr(self.services, '__itersorted__', types.MethodType(itersorted, self.services))
-        setattr(self.hosts, '__itersorted__', types.MethodType(itersorted, self.hosts))
-        setattr(self.contacts, '__itersorted__', types.MethodType(itersorted, self.contacts))
-        setattr(self.servicegroups, '__itersorted__', types.MethodType(itersorted, self.servicegroups))
-        setattr(self.hostgroups, '__itersorted__', types.MethodType(itersorted, self.hostgroups))
-        setattr(self.contactgroups, '__itersorted__', types.MethodType(itersorted, self.contactgroups))
-        setattr(self.commands, '__itersorted__', types.MethodType(itersorted, self.commands))
-        setattr(self.timeperiods, '__itersorted__', types.MethodType(itersorted, self.timeperiods))
+        setattr(self.services, '__itersorted__',
+                types.MethodType(itersorted, self.services))
+        setattr(self.hosts, '__itersorted__',
+                types.MethodType(itersorted, self.hosts))
+        setattr(self.contacts, '__itersorted__',
+                types.MethodType(itersorted, self.contacts))
+        setattr(self.servicegroups, '__itersorted__',
+                types.MethodType(itersorted, self.servicegroups))
+        setattr(self.hostgroups, '__itersorted__',
+                types.MethodType(itersorted, self.hostgroups))
+        setattr(self.contactgroups, '__itersorted__',
+                types.MethodType(itersorted, self.contactgroups))
+        setattr(self.commands, '__itersorted__',
+                types.MethodType(itersorted, self.commands))
+        setattr(self.timeperiods, '__itersorted__',
+                types.MethodType(itersorted, self.timeperiods))
 
         # Speedup authUser requests by populating _id_contact_heap with contact-names as key and
         # an array with the associated host and service ids
@@ -175,25 +258,48 @@ class LiveStatusRegenerator(Regenerator):
         setattr(self.hostgroups, '_id_contact_heap', dict())
         setattr(self.servicegroups, '_id_contact_heap', dict())
 
-        [self.hosts._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k) for (k, v) in self.hosts.items.iteritems() for c in v.contacts]
+        [
+            self.hosts._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k)
+            for (k, v) in self.hosts.items.iteritems()
+            for c in v.contacts
+        ]
         for c in self.hosts._id_contact_heap.keys():
-            self.hosts._id_contact_heap[c].sort(key=lambda x: get_obj_full_name(self.hosts.items[x]))
+            self.hosts._id_contact_heap[c].sort(
+                key=lambda x: get_obj_full_name(self.hosts.items[x])
+            )
 
         # strict: one must be an explicitly contact of a service in order to see it.
         if self.service_authorization_strict:
-            [self.services._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k) for (k, v) in self.services.items.iteritems() for c in v.contacts]
+            [
+                self.services._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k)
+                for (k, v) in self.services.items.iteritems()
+                for c in v.contacts
+            ]
         else:
             # 1. every host contact automatically becomes a service contact
-            [self.services._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k) for (k, v) in self.services.items.iteritems() for c in v.host.contacts]
+            [
+                self.services._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k)
+                for (k, v) in self.services.items.iteritems()
+                for c in v.host.contacts
+            ]
             # 2. explicit service contacts
-            [self.services._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k) for (k, v) in self.services.items.iteritems() for c in v.contacts]
+            [
+                self.services._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k)
+                for (k, v) in self.services.items.iteritems()
+                for c in v.contacts
+            ]
         # services without contacts inherit the host's contacts (no matter of strict or loose)
-        [self.services._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k) for (k, v) in self.services.items.iteritems() if not v.contacts for c in v.host.contacts]
+        [
+            self.services._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k)
+            for (k, v) in self.services.items.iteritems() if not v.contacts
+            for c in v.host.contacts
+        ]
         for c in self.services._id_contact_heap.keys():
             # remove duplicates
             self.services._id_contact_heap[c] = list(set(self.services._id_contact_heap[c]))
-            self.services._id_contact_heap[c].sort(key=lambda x: get_obj_full_name(self.services.items[x]))
-
+            self.services._id_contact_heap[c].sort(
+                key=lambda x: get_obj_full_name(self.services.items[x])
+            )
 
         if self.group_authorization_strict:
             for c in self.hosts._id_contact_heap.keys():
@@ -225,16 +331,30 @@ class LiveStatusRegenerator(Regenerator):
                         self.servicegroups._id_contact_heap.setdefault(c, []).append(v.id)
         else:
             # loose: a contact of a member becomes contact of the whole group
-            [self.hostgroups._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k) for (k, v) in self.hostgroups.items.iteritems() for h in v.members for c in h.contacts]
-            [self.servicegroups._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k) for (k, v) in self.servicegroups.items.iteritems() for s in v.members for c in s.contacts] # todo: look at mk-livestatus. what about service's host contacts?
+            [
+                self.hostgroups._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k)
+                for (k, v) in self.hostgroups.items.iteritems()
+                for h in v.members
+                for c in h.contacts
+            ]
+            [
+                self.servicegroups._id_contact_heap.setdefault(get_obj_full_name(c), []).append(k)
+                for (k, v) in self.servicegroups.items.iteritems()
+                for s in v.members
+                for c in s.contacts
+            ] # todo: look at mk-livestatus. what about service's host contacts?
         for c in self.hostgroups._id_contact_heap.keys():
             # remove duplicates
             self.hostgroups._id_contact_heap[c] = list(set(self.hostgroups._id_contact_heap[c]))
-            self.hostgroups._id_contact_heap[c].sort(key=lambda x: get_obj_full_name(self.hostgroups.items[x]))
+            self.hostgroups._id_contact_heap[c].sort(
+                key=lambda x: get_obj_full_name(self.hostgroups.items[x])
+            )
         for c in self.servicegroups._id_contact_heap.keys():
             # remove duplicates
             self.servicegroups._id_contact_heap[c] = list(set(self.servicegroups._id_contact_heap[c]))
-            self.servicegroups._id_contact_heap[c].sort(key=lambda x: get_obj_full_name(self.servicegroups.items[x]))
+            self.servicegroups._id_contact_heap[c].sort(
+                key=lambda x: get_obj_full_name(self.servicegroups.items[x])
+            )
 
         # Add another helper structure which allows direct lookup by name
         # For hosts: _id_by_host_name_heap = {'name1':id1, 'name2': id2,...}
@@ -243,41 +363,123 @@ class LiveStatusRegenerator(Regenerator):
         setattr(self.hosts, '_id_by_host_name_heap', dict([(get_obj_full_name(v), k) for (k, v) in self.hosts.items.iteritems()]))
         setattr(self.services, '_id_by_service_name_heap', dict([(get_obj_full_name(v), k) for (k, v) in self.services.items.iteritems()]))
         setattr(self.services, '_id_by_host_name_heap', dict())
-        [self.services._id_by_host_name_heap.setdefault(get_obj_full_name(v.host), []).append(k) for (k, v) in self.services.items.iteritems()]
+        [
+            self.services._id_by_host_name_heap.setdefault(get_obj_full_name(v.host), []).append(k)
+            for (k, v) in self.services.items.iteritems()
+        ]
         logger.debug("[Livestatus Regenerator] Id by Hostname heap: %s" % str(self.services._id_by_host_name_heap))
         for hn in self.services._id_by_host_name_heap.keys():
-            self.services._id_by_host_name_heap[hn].sort(key=lambda x: get_obj_full_name(self.services[x]))
+            self.services._id_by_host_name_heap[hn].sort(
+                key=lambda x: get_obj_full_name(self.services[x])
+            )
 
         # Add another helper structure which allows direct lookup by name
         # For hostgroups: _id_by_hostgroup_name_heap = {'name1':id1, 'name2': id2,...}
         # For servicegroups: _id_by_servicegroup_name_heap = {'name1':id1, 'name2': id2,...}
-        setattr(self.hostgroups, '_id_by_hostgroup_name_heap', dict([(get_obj_full_name(v), k) for (k, v) in self.hostgroups.items.iteritems()]))
-        setattr(self.servicegroups, '_id_by_servicegroup_name_heap', dict([(get_obj_full_name(v), k) for (k, v) in self.servicegroups.items.iteritems()]))
+        setattr(self.hostgroups, '_id_by_hostgroup_name_heap',
+                dict([
+                    (get_obj_full_name(v), k) for (k, v) in self.hostgroups.items.iteritems()
+                ]))
+        setattr(self.servicegroups, '_id_by_servicegroup_name_heap',
+                dict([
+                    (get_obj_full_name(v), k) for (k, v) in self.servicegroups.items.iteritems()
+                ]))
 
         # For hosts: key is a hostgroup_name, value is an array with all host_ids of the hosts in this group
         setattr(self.hosts, '_id_by_hostgroup_name_heap', dict())
-        [self.hosts._id_by_hostgroup_name_heap.setdefault(get_obj_full_name(hg), []).append(k) for (k, v) in self.hosts.items.iteritems() for hg in v.hostgroups]
+        [
+            self.hosts._id_by_hostgroup_name_heap.setdefault(get_obj_full_name(hg), []).append(k)
+            for (k, v) in self.hosts.items.iteritems()
+            for hg in v.hostgroups
+        ]
         for hg in self.hosts._id_by_hostgroup_name_heap.keys():
-            self.hosts._id_by_hostgroup_name_heap[hg].sort(key=lambda x: get_obj_full_name(self.hosts.items[x]))
+            self.hosts._id_by_hostgroup_name_heap[hg].sort(
+                key=lambda x: get_obj_full_name(self.hosts.items[x])
+            )
         # For services: key is a servicegroup_name, value is an array with all service_ids of the services in this group
         setattr(self.services, '_id_by_servicegroup_name_heap', dict())
-        [self.services._id_by_servicegroup_name_heap.setdefault(get_obj_full_name(sg), []).append(k) for (k, v) in self.services.items.iteritems() for sg in v.servicegroups]
+        [
+            self.services._id_by_servicegroup_name_heap.setdefault(get_obj_full_name(sg), []).append(k)
+            for (k, v) in self.services.items.iteritems()
+            for sg in v.servicegroups
+        ]
         for sg in self.services._id_by_servicegroup_name_heap.keys():
-            self.services._id_by_servicegroup_name_heap[sg].sort(key=lambda x: get_obj_full_name(self.services[x]))
+            self.services._id_by_servicegroup_name_heap[sg].sort(
+                key=lambda x: get_obj_full_name(self.services[x])
+            )
         # For services: key is a hostgroup_name, value is an array with all service_ids of the hosts in this group
         setattr(self.services, '_id_by_hostgroup_name_heap', dict())
-        [self.services._id_by_hostgroup_name_heap.setdefault(get_obj_full_name(hg), []).append(k) for (k, v) in self.services.items.iteritems() for hg in v.host.hostgroups]
+        [
+            self.services._id_by_hostgroup_name_heap.setdefault(get_obj_full_name(hg), []).append(k)
+            for (k, v) in self.services.items.iteritems()
+            for hg in v.host.hostgroups
+        ]
         for hg in self.services._id_by_hostgroup_name_heap.keys():
-            self.services._id_by_hostgroup_name_heap[hg].sort(key=lambda x: get_obj_full_name(self.services[x]))
-
+            self.services._id_by_hostgroup_name_heap[hg].sort(
+                key=lambda x: get_obj_full_name(self.services[x])
+            )
 
         # print self.services._id_by_host_name_heap
         for hn in self.services._id_by_host_name_heap.keys():
-            self.services._id_by_host_name_heap[hn].sort(key=lambda x: get_obj_full_name(self.services[x]))
-
+            self.services._id_by_host_name_heap[hn].sort(
+                key=lambda x: get_obj_full_name(self.services[x])
+            )
 
         # Everything is new now. We should clean the cache
         self.cache.wipeout()
+        if self.transparent_update:
+            self.clear_previous_state()
+        self.initialized = True
+
+    def save_previous_state(self):
+        """
+        Saves previous state when a new configuration is loaded.
+
+        If a previously saved state exists, the query processor will query it
+        while data is being loaded.
+        """
+        if self.initialized is False:
+            return
+        logger.debug("[Livestatus Regenerator] saving previous state")
+        for attr, klass in self.rollover_attributes.items():
+            prev_attr = "previous_%s" % attr
+            cur_state = getattr(self, attr)
+            # Copy current state in previous state
+            prev_state = klass(cur_state)
+            # Copy __itersorted__ methods and associated data
+            for attr in [a for a in dir(cur_state) if a.endswith("heap")]:
+                heap = getattr(cur_state, attr)
+                setattr(prev_state, attr, copy.copy(heap))
+            setattr(prev_state, '__itersorted__',
+                    types.MethodType(itersorted, prev_state))
+            # Sets previous state
+            setattr(self, prev_attr, prev_state)
+
+    def clear_previous_state(self):
+        """
+        Erases previously saved state after data has been loaded.
+        """
+        logger.debug("[Livestatus Regenerator] clearing previous state")
+        for attr in self.rollover_attributes:
+            prev_attr = "previous_%s" % attr
+            setattr(self, prev_attr, None)
+
+    def get_table(self, table_name):
+        """
+        Returns a given table.
+
+        This method first takes care to check if a previous state has been
+        saved, which indicates that new data is being loaded.
+
+        If a previous state exists, query from it, as soon as data has been
+        loaded (no more saved state), query the current state.
+
+        :param str table_name: The table to return
+        """
+        prev_attr = "previous_%s" % table_name
+        if getattr(self, prev_attr, None) is not None:
+            table_name = prev_attr
+        return getattr(self, table_name)
 
     def manage_initial_contact_status_brok(self, b):
         """overwrite it, because the original method deletes some values"""
@@ -328,3 +530,14 @@ class LiveStatusRegenerator(Regenerator):
 
     def before_after_hook(self, brok, obj):
         self.cache.impact_assessment(brok, obj)
+
+    def manage_program_status_brok(self, b):
+        """
+        Saves current objets state before cleaning it to continue to serve
+        queries while data is loading.
+
+        :param dict b: The received brok
+        """
+        if self.transparent_update:
+            self.save_previous_state()
+        super(LiveStatusRegenerator, self).manage_program_status_brok(b)

--- a/module/module.py
+++ b/module/module.py
@@ -127,6 +127,9 @@ class LiveStatus_broker(BaseModule, Daemon):
         self.debug = getattr(modconf, 'debug', None)
         self.debug_queries = (getattr(modconf, 'debug_queries', '0') == '1')
         self.use_query_cache = (getattr(modconf, 'query_cache', '0') == '1')
+        self.transparent_update = (
+            getattr(modconf, 'transparent_update', '0') == '1'
+        )
         if getattr(modconf, 'service_authorization', 'loose') == 'strict':
             self.service_authorization_strict = True
         else:
@@ -148,7 +151,11 @@ class LiveStatus_broker(BaseModule, Daemon):
         }
         # We need to have our regenerator now because it will need to load
         # data from scheduler before main() if in scheduler of course
-        self.rg = LiveStatusRegenerator(self.service_authorization_strict, self.group_authorization_strict)
+        self.rg = LiveStatusRegenerator(
+            self.service_authorization_strict,
+            self.group_authorization_strict,
+            self.transparent_update
+        )
 
         self.client_connections = {}  # keys will be socket of client,
         # values are LiveStatusClientThread instances
@@ -175,7 +182,9 @@ class LiveStatus_broker(BaseModule, Daemon):
         logger.info("[Livestatus Broker] Init of the Livestatus '%s'" % self.name)
         self.prepare_pnp_path()
         m = MacroResolver() # TODO: don't know/think these 2 lines are necessary..
-        m.output_macros = ['HOSTOUTPUT', 'HOSTPERFDATA', 'HOSTACKAUTHOR', 'HOSTACKCOMMENT', 'SERVICEOUTPUT', 'SERVICEPERFDATA', 'SERVICEACKAUTHOR', 'SERVICEACKCOMMENT']
+        m.output_macros = ['HOSTOUTPUT', 'HOSTPERFDATA', 'HOSTACKAUTHOR',
+                           'HOSTACKCOMMENT', 'SERVICEOUTPUT', 'SERVICEPERFDATA',
+                           'SERVICEACKAUTHOR', 'SERVICEACKCOMMENT']
         self.rg.load_external_queue(self.from_q)
 
     # This is called only when we are in a scheduler

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "livestatus",
   "types": ["module"],
-  "version": "1.4.2",
+  "version": "1.4.3",
   "homepage": "http://github.com/shinken-monitoring/mod-livestatus",
   "author": "Jean Gabès",
   "description": "Livestatus module for Shinken",


### PR DESCRIPTION
This patch implements transparent update. It prevents downtimes or void results each time a new configuration is pushed.

The deleted objects state is saved when new initial Broks are sent by a scheduler. Queries get executed from this saved state until new objects are fully loaded. Once done, the old state is erased, and queries are made from latest objects state.

To enable transparent update, set the `transparent_update` parameter to `1` in the livestatus configuration:

    define module {
        module_name        Livestatus
        module_type        livestatus
        port               50000
        ...
        transparent_update 1
        ...
    }

Also:

- Fixed a bug in `itersorted` bound method in regenerator class that crashed livestatus when a query was made during objects reloading. If an id could   not be found, return a void list rather than crashing the whole module.
- Set a null `__itersorted__` method at initialization to avoid ugly   `object has no attribute '__itersorted__'` exceptions when service  starts.
- Re-indented some (very) long and difficult to read list comprehensions