### PR TITLE
Correctly handle keepalive option

### DIFF
--- a/module/livestatus_client_thread.py
+++ b/module/livestatus_client_thread.py
@@ -227,7 +227,7 @@ class LiveStatusClientThread(threading.Thread):
 
 
     def handle_request(self, request_data):
-        response, _ = self.livestatus.handle_request(request_data)
+        response, keepalive = self.livestatus.handle_request(request_data)
 
         try:
             if not isinstance(response, (LiveStatusListResponse, type(b''))):
@@ -243,6 +243,9 @@ class LiveStatusClientThread(threading.Thread):
                 response.responseheader = 'fixed16'
             output, _ = response.respond()
             self.send_response(output)
+
+        if keepalive != 'on':
+            self.request_stop()
 
     def run(self):
         assert isinstance(self.livestatus, LiveStatus)

--- a/module/livestatus_obj.py
+++ b/module/livestatus_obj.py
@@ -110,7 +110,7 @@ class LiveStatus(object):
             return '', False
 
         cur_idx = 0
-        keepalive = False
+        keepalive = 'off'
 
         for query in queries:  # process the command(s), if any.
             # as they are sorted alphabetically, once we get one which isn't a 'command'..
@@ -123,7 +123,7 @@ class LiveStatus(object):
             cur_idx += 1
 
         if 'wait' in queries_type:
-            keepalive = True
+            keepalive = 'on'
             # we return  'wait' first and 'query' second..
             output = list(reversed(queries[cur_idx:]))
         elif len(queries[cur_idx:]):

--- a/module/livestatus_obj.py
+++ b/module/livestatus_obj.py
@@ -117,6 +117,9 @@ class LiveStatus(object):
             if query.my_type != 'command':
                 break   # then we are done.
             query.process_query()
+            # According to mk_livestatus documentation
+            # COMMAND automatically implies keep alive and behave like GET when KeepAlive is set to on.
+            keepalive = 'on'
             # according to Check_Mk, COMMAND doesn't require a response (argh!),
             # that is no response or more simply: an empty response:
             output = ''


### PR DESCRIPTION
mod-livestatus doesn't close the connection when keepalive isn't set.

It break clients who wait for server to close the connection after sending data such as https://github.com/sni/lmd as describe in https://github.com/sni/lmd/issues/24