### PR TITLE
Wrapped json support

### DIFF
--- a/module/livestatus_obj.py
+++ b/module/livestatus_obj.py
@@ -86,8 +86,14 @@ class LiveStatus(object):
             output = err
             # We need the output format in order to return the error in one way or another
             OUTPUT_FORMAT_HEADER = 'OutputFormat:'
-            outputformat = filter(lambda x: x.startswith(OUTPUT_FORMAT_HEADER), data.splitlines()) or  ['OutputFormat: csv']
-            outputformat = outputformat[0][len(OUTPUT_FORMAT_HEADER)+1:].strip()
+            outputformat = next(
+                (
+                    line[len(OUTPUT_FORMAT_HEADER)+1:].strip()
+                    for line in data.splitlines()
+                    if line.startswith(OUTPUT_FORMAT_HEADER)
+                ),
+                'csv'  # Default value
+            )
         # Ok now we can return something
         response = LiveStatusResponse(outputformat=outputformat)
         response.set_error(code, output)

--- a/module/livestatus_obj.py
+++ b/module/livestatus_obj.py
@@ -86,8 +86,14 @@ class LiveStatus(object):
             output = err
             # We need the output format in order to return the error in one way or another
             OUTPUT_FORMAT_HEADER = 'OutputFormat:'
-            outputformat = filter(lambda x: x.startswith(OUTPUT_FORMAT_HEADER), data.splitlines()) or  ['OutputFormat: csv']
-            outputformat = outputformat[0][len(OUTPUT_FORMAT_HEADER)+1:].strip()
+            outputformat = next(
+                (
+                    line[len(OUTPUT_FORMAT_HEADER)+1:].strip()
+                    for line in data.splitlines()
+                    if line.startswith(OUTPUT_FORMAT_HEADER)
+                ),
+                default='csv'
+            )
         # Ok now we can return something
         response = LiveStatusResponse(outputformat=outputformat)
         response.set_error(code, output)

--- a/module/livestatus_obj.py
+++ b/module/livestatus_obj.py
@@ -85,15 +85,15 @@ class LiveStatus(object):
             code = 500
             output = err
             # We need the output format in order to return the error in one way or another
-            OUTPUT_FORMAT_HEADER = 'OutputFormat:'
-            outputformat = next(
-                (
-                    line[len(OUTPUT_FORMAT_HEADER)+1:].strip()
-                    for line in data.splitlines()
-                    if line.startswith(OUTPUT_FORMAT_HEADER)
-                ),
-                'csv'  # Default value
-            )
+        OUTPUT_FORMAT_HEADER = 'OutputFormat:'
+        outputformat = next(
+            (
+                line[len(OUTPUT_FORMAT_HEADER)+1:].strip()
+                for line in data.splitlines()
+                if line.startswith(OUTPUT_FORMAT_HEADER)
+            ),
+            'csv'  # Default value
+        )
         # Ok now we can return something
         response = LiveStatusResponse(outputformat=outputformat)
         response.set_error(code, output)

--- a/module/livestatus_obj.py
+++ b/module/livestatus_obj.py
@@ -71,6 +71,7 @@ class LiveStatus(object):
 
     def handle_request(self, data):
         try:
+            outputformat='csv'
             return self.handle_request_and_fail(data)
         except LiveStatusQueryError as err:
             # LiveStatusQueryError(404, table)
@@ -85,15 +86,15 @@ class LiveStatus(object):
             code = 500
             output = err
             # We need the output format in order to return the error in one way or another
-        OUTPUT_FORMAT_HEADER = 'OutputFormat:'
-        outputformat = next(
-            (
-                line[len(OUTPUT_FORMAT_HEADER)+1:].strip()
-                for line in data.splitlines()
-                if line.startswith(OUTPUT_FORMAT_HEADER)
-            ),
-            'csv'  # Default value
-        )
+            OUTPUT_FORMAT_HEADER = 'OutputFormat:'
+            outputformat = next(
+                (
+                    line[len(OUTPUT_FORMAT_HEADER)+1:].strip()
+                    for line in data.splitlines()
+                    if line.startswith(OUTPUT_FORMAT_HEADER)
+                ),
+                'csv'  # Default value
+            )
         # Ok now we can return something
         response = LiveStatusResponse(outputformat=outputformat)
         response.set_error(code, output)

--- a/module/livestatus_obj.py
+++ b/module/livestatus_obj.py
@@ -84,8 +84,12 @@ class LiveStatus(object):
             logger.error("[Livestatus] Back trace of this exception: %s", trb)
             code = 500
             output = err
+            # We need the output format in order to return the error in one way or another
+            OUTPUT_FORMAT_HEADER = 'OutputFormat:'
+            outputformat = filter(lambda x: x.startswith(OUTPUT_FORMAT_HEADER), data.splitlines()) or  ['OutputFormat: csv']
+            outputformat = outputformat[0][len(OUTPUT_FORMAT_HEADER)+1:].strip()
         # Ok now we can return something
-        response = LiveStatusResponse()
+        response = LiveStatusResponse(outputformat=outputformat)
         response.set_error(code, output)
         if 'fixed16' in data:
             response.responseheader = 'fixed16'

--- a/module/livestatus_response.py
+++ b/module/livestatus_response.py
@@ -161,7 +161,7 @@ class LiveStatusResponse:
 
     def _generate_wrapped_json_output(self):
         self.output = loads(reduce(lambda acc, x: acc+x, self.output))
-        self.output = {'data': self.output, 'errors': {}, 'total': len(self.output)}
+        self.output = {'data': self.output, 'failed': {}, 'total': len(self.output)}
         if self.error:
             self.output['errors']['shinken-error'] = self.error
         self.output = LiveStatusListResponse([dumps(self.output) + '\n'])

--- a/module/livestatus_response.py
+++ b/module/livestatus_response.py
@@ -135,7 +135,7 @@ class LiveStatusResponse:
             self.error = msg
         else:
             del self.output[:]
-            self.output.append( LiveStatusQueryError.messages[statuscode] % data )
+            self.output.append(msg)
         self.statuscode = statuscode
 
     def load(self, query):


### PR DESCRIPTION
This pull request adds support for the output format "wrapped_json".

This format, supported by LMD, includes information about the data length and the errors that may have been occurred. Summing up, this format returns additional information in the response.

The aiming of including this format is the interest to know what happened if a query fails for some reason in order to fix it or handle the error if there was any, because at the moment if the query fails, the reader in the socket cannot know it without looking at the broker logs.