### PR TITLE
Module restart

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -437,5 +437,7 @@ class LiveStatus_broker(BaseModule, Daemon):
                 # in our input queue:
                 time.sleep(0.1)
 
+            self.modules_manager.try_to_restart_deads()
+
         # end: while not self.interrupted:
         self.do_stop()

--- a/module/module.py
+++ b/module/module.py
@@ -403,7 +403,14 @@ class LiveStatus_broker(BaseModule, Daemon):
 
             if db_commit_next_time < now:
                 db_commit_next_time = now + 3  # only commit every ~3 secs
-                self.db.commit_and_rotate_log_db()
+                try:
+                    self.db.commit_and_rotate_log_db()
+                except Exception as err:
+                    logger.exception(
+                        "[%s] Warning: The mod %s raise an exception: %s,"
+                        "I'm tagging it to restart later",
+                        self.name, self.db.get_name(), err)
+                    self.modules_manager.set_to_restart(self.db)
 
             try:
                 l = self.to_q.get(True, 1)


### PR DESCRIPTION
Exception while commit in logstore modules make livestatus hang. Theses commit fixes the issue.