### PR TITLE
fix numerical host_name

### DIFF
--- a/module/livestatus_query.py
+++ b/module/livestatus_query.py
@@ -722,6 +722,8 @@ class LiveStatusQuery(object):
             converter = find_filter_converter(self.table, 'lsm_'+attribute)
             if converter:
                 reference = converter(reference)
+            if attribute == 'host_name':
+                reference = str(reference)
             if isinstance(reference, str):
                 reference = reference.decode('utf8','ignore')
         attribute = 'lsm_' + attribute


### PR DESCRIPTION
When a host has a host_name numeric, it dosen't return logs. See https://github.com/shinken-monitoring/mod-livestatus/issues/39. This patch will fix it.   